### PR TITLE
fix: refund residual ETH in placeMultipleBids to prevent locked funds from bulk bid truncation

### DIFF
--- a/src/EnergyBiddingMarket.sol
+++ b/src/EnergyBiddingMarket.sol
@@ -191,9 +191,18 @@ contract EnergyBiddingMarket is UUPSUpgradeable, OwnableUpgradeable {
         if (beginHour + 3600 > endHour)
             revert EnergyBiddingMarket__WrongHoursProvided(beginHour, endHour);
 
-        uint256 price = msg.value / ((amount * (endHour - beginHour)) / 3600);
+        uint256 totalEnergy = ((amount * (endHour - beginHour)) / 3600);
+        uint256 price = msg.value / totalEnergy;
+        uint256 totalCost = price * totalEnergy;
+        uint256 excess = msg.value - totalCost;
+
         for (uint256 i = beginHour; i < endHour; i += 3600) {
             _placeBid(i, amount, price);
+        }
+
+        if (excess > 0) {
+            (bool success,) = msg.sender.call{value: excess}("");
+            require(success, "ETH transfer failed");
         }
     }
 


### PR DESCRIPTION
### Summary

This PR ensures that any residual ETH left after computing `price * amount * hours` in `placeMultipleBids(beginHour, endHour, amount)` is correctly refunded to the user. This avoids unnecessary and silent loss of funds caused by integer division during bulk bidding.

---

### What Changed

- Refactored the `placeMultipleBids` logic to:
  - Calculate total energy (`amount * hours`)
  - Compute the exact `price` using integer division
  - Calculate `totalCost` and `excess`
  - Place bids per hour using `_placeBid(...)`
  - Refund the `excess` (if any) using a low-level `.call{value: excess}`

```solidity
uint256 totalEnergy = ((amount * (endHour - beginHour)) / 3600);
uint256 price = msg.value / totalEnergy;
uint256 totalCost = price * totalEnergy;
uint256 excess = msg.value - totalCost;

for (uint256 i = beginHour; i < endHour; i += 3600) {
    _placeBid(i, amount, price);
}

if (excess > 0) {
    (bool success,) = msg.sender.call{value: excess}("");
    require(success, "ETH transfer failed");
}
```

---

### ✅ Test Added

- `test_PlaceMultipleBidsResiduals`: Ensures that ETH residuals from truncated division are **not** retained in the contract and are correctly refunded to the sender.

```solidity
assertEq(address(market).balance, totalUsed, "Contract should not retain residuals");
```

---

### Why It Matters

Residuals are small in single bids, but scale up in long-range multi-hour bidding scenarios. This fix:

- Prevents permanent fund retention due to rounding
- Improves UX and frontend compatibility
- Ensures users only pay what is actually used to place their bids

---

### Linked Issue

Closes #12
