### PR TITLE
fix: refund residual ETH in array-based placeMultipleBids to prevent locked funds

### DIFF
--- a/src/EnergyBiddingMarket.sol
+++ b/src/EnergyBiddingMarket.sol
@@ -218,9 +218,17 @@ contract EnergyBiddingMarket is UUPSUpgradeable, OwnableUpgradeable {
 
         uint256 bidsAmount = biddingHours.length;
 
-        uint256 price = msg.value / (amount * bidsAmount);
+        uint256 totalEnergy = amount * bidsAmount;
+        uint256 price = msg.value / totalEnergy;
+        uint256 totalCost = price * totalEnergy;
+        uint256 excess = msg.value - totalCost;
         for (uint256 i = 0; i < bidsAmount; i++) {
             _placeBid(biddingHours[i], amount, price);
+        }
+
+        if (excess > 0) {
+            (bool success,) = msg.sender.call{value: excess}("");
+            require(success, "ETH transfer failed");
         }
     }
 


### PR DESCRIPTION
### Summary

This PR updates the `placeMultipleBids(uint256[] memory biddingHours, uint256 amount)` function to handle and refund residual ETH left over from integer truncation during price calculation across multiple bids.

Previously, the contract calculated `price = msg.value / (amount * bidsAmount)` using integer division, which could result in a small residual (`msg.value % (amount * bidsAmount)`) being **silently retained** by the contract. This PR fixes that by computing and refunding the excess ETH after all bids are placed.

---

### ✅ What Changed

- Updated price computation logic:
  ```solidity
  uint256 totalEnergy = amount * bidsAmount;
  uint256 price = msg.value / totalEnergy;
  uint256 totalCost = price * totalEnergy;
  uint256 excess = msg.value - totalCost;
  ```

- Added a refund mechanism using low-level `call`:
  ```solidity
  if (excess > 0) {
      (bool success, ) = msg.sender.call{value: excess}("");
      require(success, "ETH transfer failed");
  }
  ```

- Placed all bids using `_placeBid(...)` with the computed price as before.

---

### ✅ Test Added

- `test_ArrayBulkBidResiduals` was added to validate:
  - ETH residuals are no longer retained
  - The contract balance only reflects actual bid cost
  - Any leftover ETH is correctly refunded to the sender

```solidity
assertEq(address(market).balance, totalUsed, "Full amount locked");
```

---

### ✅ Why It Matters

- Prevents accumulation of unused ETH in the contract
- Ensures users are only charged for what is actually used
- Makes multi-hour bidding more predictable and economically fair

This is particularly important for use cases involving long bidding intervals or integrations with frontends where value precision may vary.

---

### Linked Issue

Closes #14
