### PR TITLE
fix: add zero address validation to whitelistSeller to prevent invalid sellers

### DIFF
--- a/src/EnergyBiddingMarket.sol
+++ b/src/EnergyBiddingMarket.sol
@@ -275,6 +275,7 @@ contract EnergyBiddingMarket is UUPSUpgradeable, OwnableUpgradeable {
     }
 
     function whitelistSeller(address seller, bool enable) external onlyOwner {
+        require(seller != address(0), "Invalid seller address");
         s_whitelistedSellers[seller] = enable;
     }
 


### PR DESCRIPTION
### Summary

This PR adds a sanity check in the `whitelistSeller` function to prevent the zero address (`address(0)`) from being whitelisted as a seller.

Without this check, it’s possible to whitelist an invalid or uninitialized address, which can lead to phantom sellers, misrouted funds, or logical inconsistencies in downstream logic or integrations.

---

### ✅ What Changed

- Added:
  ```solidity
  require(seller != address(0), "Invalid seller address");
  ```
- Ensures only valid, non-zero addresses can be whitelisted

---

### ✅ Why It Matters

Whitelisting `address(0)` can cause:
- "Ghost" seller entries that no one controls
- Funds being sent to an unrecoverable address
- Confusing data for platforms and dashboards
- Breakage in integrations assuming all sellers are valid

This is a defensive best practice aligned with common Solidity patterns (e.g., ERC20, Ownable).

---

### Linked Issue

Closes #16
